### PR TITLE
fix: clean coures api comments and imports

### DIFF
--- a/lib/service/couresApi.dart
+++ b/lib/service/couresApi.dart
@@ -2,11 +2,8 @@ import 'dart:convert';
 import 'dart:async';
 import 'dart:developer';
 import 'package:app_deaf/models/Coures.dart';
-// import 'package:app_deaf/models/post.dart';
 import 'package:app_deaf/utils/constarts.dart';
 import 'package:http/http.dart' as http;
-
-import 'package:app_deaf/utils/constarts.dart';
 
 class CouresApi {
   static Future<List<Coures>> futureCouresApi() async {
@@ -17,7 +14,7 @@ class CouresApi {
     final response = await http.get(Uri.parse(ursl));
 
     if (response.statusCode == 200) {
-      //pares data
+      // parse data
       final List result = json.decode(response.body);
       return result.map((e) => Coures.fromJson(e)).toList();
     } else {


### PR DESCRIPTION
## Summary
- correct "parse data" comment in Coures API
- remove duplicate imports and leftover comment

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a1cd99528832b8e6ed25407ecde8b