### PR TITLE
Rename profile page and update references

### DIFF
--- a/lib/pages/menu/navbar.dart
+++ b/lib/pages/menu/navbar.dart
@@ -9,7 +9,7 @@ import 'package:app_deaf/models/signinModel.dart';
 import 'package:app_deaf/pages/coures.dart';
 import 'package:app_deaf/pages/history.dart';
 import 'package:app_deaf/pages/home/home.dart';
-import 'package:app_deaf/pages/proflie.dart';
+import 'package:app_deaf/pages/profile.dart';
 import 'package:app_deaf/routers.dart';
 import 'package:app_deaf/utils/app_controller.dart';
 
@@ -50,7 +50,7 @@ class _NavbarPageState extends State<NavbarPage> {
                   HomaPage(),
                   CouresPage(),
                   HistoryPage(id: widget.id,),
-                  ProfliePage(
+                  ProfilePage(
                     id: widget.id,
                   ),
                 ],

--- a/lib/pages/profile.dart
+++ b/lib/pages/profile.dart
@@ -17,19 +17,19 @@ import 'package:http/http.dart' as http;
 import 'package:dio/dio.dart' as dioApi hide FormData;
 import 'package:dio/src/form_data.dart' as dioFormdata;
 
-class ProfliePage extends StatefulWidget {
+class ProfilePage extends StatefulWidget {
   final String id;
-  const ProfliePage({
+  const ProfilePage({
     Key? key,
     required this.id,
     List<ProfileModel>? profileModel,
   }) : super(key: key);
 
   @override
-  State<ProfliePage> createState() => _ProfliePageState();
+  State<ProfilePage> createState() => _ProfilePageState();
 }
 
-class _ProfliePageState extends State<ProfliePage> {
+class _ProfilePageState extends State<ProfilePage> {
   final ImagePicker _imagePicker = ImagePicker();
 
   final file = File;

--- a/lib/pages/signin_signup/signin.dart
+++ b/lib/pages/signin_signup/signin.dart
@@ -7,7 +7,7 @@ import 'dart:math';
 // import 'package:app_deaf/service/couresApi.dart';
 import 'package:app_deaf/models/signinModel.dart';
 import 'package:app_deaf/pages/menu/navbar.dart';
-import 'package:app_deaf/pages/proflie.dart';
+import 'package:app_deaf/pages/profile.dart';
 import 'package:app_deaf/routers.dart';
 import 'package:app_deaf/service/signUpApi.dart';
 import 'package:app_deaf/service/singinApi.dart';

--- a/lib/routers.dart
+++ b/lib/routers.dart
@@ -3,7 +3,7 @@ import 'package:app_deaf/pages/coures.dart';
 import 'package:app_deaf/pages/history.dart';
 import 'package:app_deaf/pages/home/home.dart';
 import 'package:app_deaf/pages/menu/navbar.dart';
-import 'package:app_deaf/pages/proflie.dart';
+import 'package:app_deaf/pages/profile.dart';
 import 'package:app_deaf/pages/signin_signup/reset_password.dart';
 import 'package:app_deaf/pages/signin_signup/signin.dart';
 import 'package:app_deaf/pages/signin_signup/signup.dart';
@@ -17,7 +17,7 @@ import 'package:flutter/material.dart';
 //   "/coures":(BuildContext context) => CouresPage(),
 //   // "/":(BuildContext context) => ContentPage(),
 //   "/history":(BuildContext context) => HistoryPage(),
-//   "/profile":(BuildContext context) => ProfliePage(),
+//   "/profile":(BuildContext context) => ProfilePage(),
 
 // };
 

--- a/lib/service/profileApi.dart
+++ b/lib/service/profileApi.dart
@@ -21,7 +21,7 @@
 // Security
 // Insights
 // Settings
-// Flutter-Deaf/lib/pages/proflie.dart
+// Flutter-Deaf/lib/pages/profile.dart
 // @kittipong199
 // kittipong199 login done next is login to profile
 // Latest commit 8f9cb4d 4 days ago
@@ -36,18 +36,18 @@
 // import 'package:flutter/material.dart';
 // import 'package:image_picker/image_picker.dart';
 
-// class ProfliePage extends StatefulWidget {
+// class ProfilePage extends StatefulWidget {
 //   final String id;
-//   const ProfliePage({
+//   const ProfilePage({
 //     Key? key,
 //     required this.id,
 //   }) : super(key: key);
 
 //   @override
-//   State<ProfliePage> createState() => _ProfliePageState();
+//   State<ProfilePage> createState() => _ProfilePageState();
 // }
 
-// class _ProfliePageState extends State<ProfliePage> {
+// class _ProfilePageState extends State<ProfilePage> {
 //   final ImagePicker _imagePicker = ImagePicker();
 //   final file = File;
 


### PR DESCRIPTION
## Summary
- rename typo'd `proflie.dart` to `profile.dart`
- rename `ProfliePage`/`_ProfliePageState` to `ProfilePage`/`_ProfilePageState`
- update imports and references across navbar, sign-in, routing, and profile service files

## Testing
- `flutter build apk --debug` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_689a1ceffd50832b991c617e4e5acbe5